### PR TITLE
fix/cards-merging

### DIFF
--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -1,4 +1,4 @@
-import { mutation, query, internalQuery } from './_generated/server'
+import { mutation, query } from './_generated/server'
 import { v } from 'convex/values'
 
 export const getRetroNotes = query({

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from './_generated/server'
+import { mutation, query, internalQuery } from './_generated/server'
 import { v } from 'convex/values'
 
 export const getRetroNotes = query({
@@ -33,7 +33,33 @@ export const remove = mutation({
   args: { id: v.id('notes') },
   handler: async (ctx, args) => {
     const note = await ctx.db.get(args.id)
-    if (note) await ctx.db.delete(note._id)
+
+    if (!note) {
+      return
+    }
+
+
+    const childrenNotes = await ctx.db.query('notes')
+      .filter((q) => q.eq(q.field('mergeParentId'), note._id))
+      .collect()
+
+    if (childrenNotes.length > 0) {
+      const firstChild = childrenNotes.shift()
+
+      if (firstChild) {
+        await ctx.db.patch(firstChild._id, {
+          mergeParentId: undefined
+        })
+
+        for (let childNote of childrenNotes) {
+          await ctx.db.patch(childNote._id, {
+            mergeParentId: firstChild?._id,
+          })
+        }
+      }
+    }
+    
+    await ctx.db.delete(note._id)
     return note
   }
 })
@@ -134,5 +160,17 @@ export const merge = mutation({
     await ctx.db.patch(source._id, {
       mergeParentId: parent._id,
     })
+
+    const childrenNotes = await ctx.db.query('notes')
+      .filter((q) => q.eq(q.field('mergeParentId'), source._id))
+      .collect()
+
+    if (childrenNotes.length > 0) {
+      for (let childNote of childrenNotes) {
+        await ctx.db.patch(childNote._id, {
+          mergeParentId: parent._id,
+        })
+      }
+    }
   }
 })

--- a/src/components/dropdownSelect/index.tsx
+++ b/src/components/dropdownSelect/index.tsx
@@ -40,6 +40,13 @@ export default function DropdownSelect(props: DropdownSelectProps) {
     return styles.join(' ')
   }, [selected])
 
+  const parsedName = useMemo(() => {
+    if (!selected) return ''
+
+    const name = String(selected.name).slice(0, 10)
+    return name + '...'
+  }, [selected])
+
   useEffect(() => {
     const handleClickOutside = (event: { target: any }) => {
       if (
@@ -54,6 +61,7 @@ export default function DropdownSelect(props: DropdownSelectProps) {
       document.removeEventListener("click", handleClickOutside, true);
     };
   }, []);
+
 
   return (
     <div className="relative" ref={ref}>
@@ -72,7 +80,7 @@ export default function DropdownSelect(props: DropdownSelectProps) {
                 src={selected.avatar}
                 alt={selected.name}
               />
-              {selected.name}
+              {parsedName}
               <FontAwesomeIcon icon={faCaretDown} className="ml-4 float-right"/>
             </div>
           ) : (

--- a/src/components/note/index.tsx
+++ b/src/components/note/index.tsx
@@ -4,7 +4,7 @@ import NoteCard from "./card";
 
 interface NoteProps {
   note: Doc<"notes">;
-  user: Doc<"users"> | undefined | null;
+  users: Doc<"users">[] | any;
   me?: Doc<"users"> | undefined | null;
   actionType?: boolean;
   blur?: boolean
@@ -16,19 +16,21 @@ interface NoteProps {
 export default function Note(props: NoteProps) {
   const {
     note,
-    user,
     me,
     actionType,
     blur = false,
     childrenNotes = [],
-    highlighted
+    highlighted,
+    users = []
   } = props;
+
+  const getUser = (id: string) => users ? users?.find(u => u._id === id) : null
 
   return (
     <div className={`merge-container ${highlighted ? 'highlighted' : ''}`}>
       <NoteCard
         note={note}
-        user={user}
+        user={getUser(note.userId)}
         me={me}
         actionType={actionType}
         blur={blur}
@@ -40,7 +42,7 @@ export default function Note(props: NoteProps) {
         <NoteCard
           key={child._id}
           note={child}
-          user={user}
+          user={getUser(child.userId)}
           me={me}
           actionType={actionType}
           blur={blur}

--- a/src/components/note/index.tsx
+++ b/src/components/note/index.tsx
@@ -24,7 +24,7 @@ export default function Note(props: NoteProps) {
     users = []
   } = props;
 
-  const getUser = (id: string) => users ? users?.find(u => u._id === id) : null
+  const getUser = (id: string) => users ? users?.find((u: Doc<"users">) => u._id === id) : null
 
   return (
     <div className={`merge-container ${highlighted ? 'highlighted' : ''}`}>


### PR DESCRIPTION
## Fixes

- "Assign field" text truncate on action item card;
- Fixed a bug when a note with children notes got deleted;
- Fixed a bug when a note with children notes got merged into another card;
- Fixed a bug where a merged note had the wrong owner being shown;
- Fixed a bug where it was possible to merge cards from different lanes.